### PR TITLE
Report N70, N80, N90 lengths.

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -591,7 +591,7 @@ void print_n50(vector<size_t>& lengths, const bool flag_html, const bool flag_js
             if(n50_total_length <= sum) break;
         }
         n50_length = lengths[sequence_index];
-	n50_sequence_index=sequence_index;
+        n50_sequence_index=sequence_index;
         for(;sequence_index < lengths.size(); sequence_index++) {
             sum += lengths[sequence_index];
             if(n70_total_length <= sum) break;


### PR DESCRIPTION
Note abyss-fac reports n80 lengths, and we can know what the most of the genome look like in terms of scaffold/contig sizes. fatt stat is two fold faster and report both scaffold and contig stats from single scaffold input.
It is a great win if fatt stat reported the sizes at higher coverage say N70, N80, and N90. 
This implementation is ad hoc, but I don't have a reason to write in a more general way:- say prepare arrays of reporting points.
