### PR TITLE
N50, N70, ..., N90 bug fix

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -633,43 +633,18 @@ void print_n50(vector<size_t>& lengths, const bool flag_html, const bool flag_js
 {
     sort(lengths.rbegin(), lengths.rend());
     const size_t total_length = accumulate(lengths.begin(), lengths.end(), 0ull);
-    size_t n50_sequence_index = (size_t)-1;
+    size_t n50_sequence_index = 0;
     size_t n50_length = 0;
-    size_t n70_sequence_index = (size_t)-1;
+    size_t n70_sequence_index = 0;
     size_t n70_length = 0;
-    size_t n80_sequence_index = (size_t)-1;
+    size_t n80_sequence_index = 0;
     size_t n80_length = 0;
-    size_t n90_sequence_index = (size_t)-1;
+    size_t n90_sequence_index = 0;
     size_t n90_length = 0;
     size_t max_length = 0;
     size_t min_length = 0;
     size_t avg_length = 0;
-    if(total_length < 1){
-      if(flag_html) { // anyway wrong input
-        cout << "<tr><td></td><td>size (bp)</td><td>number</td></tr>\n";
-        cout << "<tr><td>max</td><td>" << 0 << "</td><td>1</td></tr>\n";
-        cout << "<tr><td>N50</td><td>" << 0 << "</td><td>" << (0) << "</td></tr>\n";
-        cout << "<tr><td>min</td><td>" << 0 << "</td><td>" << lengths.size() << "</td></tr>\n";
-        cout << "<tr><td>avg</td><td>" << 0 << "</td><td></td></tr>\n";
-      } else if(flag_json) {// wrong value but should be processible?
-        cout << "{\"total_length\": " << total_length;
-        cout << ",\"count\": " << lengths.size();
-        cout << ",\"max_length\": " << max_length;
-        cout << ",\"n50\": " << 0 << ",\"n50num\": " << (0);
-        cout << ",\"n70\": " << 0 << ",\"n70num\": " << (0);
-        cout << ",\"n80\": " << 0 << ",\"n80num\": " << (0);
-        cout << ",\"n90\": " << 0 << ",\"n90num\": " << (0);
-        cout << ",\"avg\": " << avg_length;
-        cout << ",\"min\": " << min_length;
-        cout << "}";
-      } else {  // assume human process
-        cout << "Total # of bases = " << total_length << "\n";
-        cout << "# of scaffolds = " << lengths.size() << "\n";
-        cout << "Possible Input error!\n";
-      }
-      return;
-    }
-    { // lengths cannot be empty when total_length >= 1;
+    if(total_length > 0){
         size_t sequence_index;
         size_t sum = 0;
         const size_t n50_total_length = (size_t)((total_length + 1ull) * 0.5);


### PR DESCRIPTION
After the for loop the indices point to the next scaffold/contigs.
Resetting only the sequence_index was a severe bug.
Resetting both the index and sum should be ok. 
But, it should be just redundant recalculation of the same thing.

Here is a test fasta file to check the behavior :)

```
>a
acgtacgtacgtaagNNNNNNNNNNNNNNNNNagaatatcaggatatagagatca
>b
acgatatacagata
```
