### PR TITLE
Eof handling

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -238,7 +238,7 @@ public:
 //    size_t tellg() { return ist.tellg(); }
     off_t get_offset() {return off_count; }
     size_t len() { return strlen(b); }
-    void seekg(off_t offset) { ist.seekg(offset); }
+    void seekg(off_t offset) {ist.clear(); ist.seekg(offset); } // clear eofbit before seeking
     void registerHeaderLine() {
         const size_t len_with_gt = len();
         if(len_with_gt == 0u) return;


### PR DESCRIPTION
When performing 

```
fatt extract --file seqlist a.fasta
```

after 

```
fatt index a.fasta
```

if the seqlist contains the last element of the a.fasta file, retrieval of any record after the specific entry were failing. To my understanding, the situation is caused because no code clear the eof bit which was set when reading the last entry.  The attached patch clears every time before seekg().  This could be overkill and clearing after hitting the eof might be better, though I did not analyze in depth if it can be safely done.  I am not sure if clearing eof just after finding eof is safe, but clearing before seek should be safe albeit it may not be best in terms of performance, and the performance penalty should not be too large.
