### PR TITLE
Warn if the index is older than the fasta/fastq file.

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -94,6 +94,16 @@ static string get_index_file_name(const char* fastq_file_name)
     return index_file_name;
 }
 
+static bool index_older_than_file(const string file_name, const string index_file_name)
+{
+    struct stat s, s2;
+    int retf = stat(file_name.c_str(), &s);
+    if(retf != 0) return false;
+    retf = stat(index_file_name.c_str(), &s2);
+    if(retf != 0) return false;
+    return s.st_mtime > s2.st_mtime;
+}
+
 static bool doesIndexExist(const char* fastq_file_name)
 {
     return access(get_index_file_name(fastq_file_name).c_str(), F_OK) == 0;
@@ -995,6 +1005,10 @@ void do_extract(int argc, char** argv)
         if(use_index) {
             const bool is_fastq = is_file_fastq(file_name);
             const string index_file_name = get_index_file_name(file_name);
+            if(index_older_than_file(file_name, index_file_name)){
+                cerr << "Warning: index file " << index_file_name << 
+                      " is older than " << file_name << endl;
+            }
             try {
                 sqdb::Db db(index_file_name.c_str());
                 if(param_start == -1) {


### PR DESCRIPTION
One may forget updating the index file and wonder why they cannot extract (find) the specific sequence that really exist in the fasta/fastq file. The index file should be constructed based on the fasta file and thus would have newer timestamp than the fasta file under normal condition. Giving a warning message when the index file is older than the fasta file may help them to understand the situation.  The order of time stamp may be disturbed when copied without -p option, but I feel the warning outweigh the silence in such cases.
