### PR TITLE
argment number check inconsistent with its function

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -2463,6 +2463,7 @@ public:
             ost << '>' << s.name;
             if(!s.description.empty()) ost << ' ' << s.description;
             ost << '\n';
+            ost << s.sequence << endl;
         }
         return true;
     }


### PR DESCRIPTION
When trying to use split command in fatt edit following message was obtained:

ERROR: # of the argument is invalid.
usage: split <sequence name> <split position (0-origin)> <left sequence name> <right sequence name>
The base at the split position goes to the right sequence.

It appears just a simple error. That the code checks the number of argument to be 3 rather than 4.
