### PR TITLE
deletion of sequences in edit function

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -2659,6 +2659,7 @@ public:
         }
         sequences[new_name].qv = sequences[old_name].qv;
         reverse(sequences[new_name].qv.begin(),sequences[new_name].qv.end());
+        sequences.erase(old_name);
         return true;
     }
     bool joinSequence(const string& left_sequence_name, const string& right_sequence_name, const string& new_sequence_name) {
@@ -2727,6 +2728,7 @@ public:
             left_seq.qv.assign(orig_seq.qv.begin(), orig_seq.qv.begin() + pos);
             right_seq.qv.assign(orig_seq.qv.begin() + pos, orig_seq.qv.end());
         }
+        sequences.erase(seq_name);
         return true;
     }
     void printSequence(const vector<string>& subargs) {

--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -2624,6 +2624,13 @@ public:
         sequences.erase(sequences.find(old_name));
         return true;
     }
+    bool deleteSequence(const string& old_name) {
+        if(sequences.count(old_name) == 0) {
+            cerr << "Could not find a sequence '" << old_name << "', which you tried to delete\n"; return false;
+        }
+        sequences.erase(old_name);
+        return true;
+    }
     bool duplicateSequence(const string& old_name, const string& new_name) {
         if(sequences.count(old_name) == 0) {
             cerr << "Could not find a sequence '" << old_name << "', which you tried to duplicate to '" << new_name << "'\n"; return false;
@@ -2917,6 +2924,16 @@ public:
                     cerr << "ERROR: an error occurred." << endl;
                     exit(2);
                 }
+            } else if(cmd == "delete") {
+                if(subargs.size() != 1) {
+                    cerr << "ERROR: # of the argument is invalid.\n";
+                    cerr << "usage: delete <sequence name>\n";
+                    return;
+                }
+                if(!deleteSequence(subargs[0])) {
+                    cerr << "ERROR: an error occurred." << endl;
+                    exit(2);
+                }
             } else if(cmd == "complement") {
                 if(subargs.size() != 2) {
                     cerr << "ERROR: # of the argument is invalid.\n";
@@ -3121,6 +3138,7 @@ void show_help(const char* subcommand)
         cerr << "\t\tloadone\tload a specified sequence in a file (arg1) with name arg2 into memory (index is used when available)\n";
         cerr << "\t\tsaveone\tsave a specified sequence (arg2) into a file (arg1)\n";
         cerr << "\t\trename\trename a sequence (arg1) into arg2\n";
+        cerr << "\t\tdelete\tdelete a sequence (arg1)\n";
         cerr << "\t\tsetdesc\tset a description (arg2) to a specified sequence (arg1)\n";
         cerr << "\t\ttrim5\ttrim the 5'-end of a specified sequence (arg1) in memory by arg2 bp\n";
         cerr << "\t\ttrim3\ttrim the 3'-end of a specified sequence (arg1) in memory by arg2 bp\n";


### PR DESCRIPTION
The first commit 946f54d adds a delete function in fatt edit. This function was regarded just as a missing function and perhaps no compatibility issue.

The second commit  b7e4f1f changes the split and complement functions of fatt edit so that the source sequence will be deleted upon call to this function. Join function already deleted source sequences and it would perhaps more natural to delete the original on split and complement as well.  However, this is apparently incompatible change that old edit script may not work as before.