### PR TITLE
Return type error.

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -207,7 +207,7 @@ public:
         line_count = 0;
         off_count = 0;
         fileName = file_name;
-        return ist;
+        return true;
     }
     void close() {
         ist.close();


### PR DESCRIPTION
bool open(const char* file_name) should return true or false.  This caused error with g++5.2.1 --std=c++11.