### PR TITLE
Extract based on regex match on the defline

### DIFF
--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -207,7 +207,7 @@ public:
         line_count = 0;
         off_count = 0;
         fileName = file_name;
-        return ist;
+        return true;
     }
     void close() {
         ist.close();

--- a/src/fatt.cc
+++ b/src/fatt.cc
@@ -3036,6 +3036,7 @@ void show_help(const char* subcommand)
         cerr << "Usage: fatt extract [options...] <FAST(A|Q) files>\n\n";
         cerr << "--unique\tOutput only unique reads. Reads with the same read name are removed.\n";
         cerr << "--seq\tSpecify the name of the read to be retrieved. You can specify this option as many times as you wish.\n";
+        cerr << "--regex\tSpecify a regular expression. The deflines (i.e. read name AND description) are searched for a match. \n";
         cerr << "--file\tSpecify a file in which you listed the read names. One line, one read.\n";
         cerr << "--stdin\tRead the list of read names from stdin. It may be useful when you combine with *NIX pipe.\n";
         cerr << "--reverse\tReverse the extracting condition. It is like -v option of grep.\n";

--- a/wscript
+++ b/wscript
@@ -13,7 +13,7 @@ def configure(conf):
         conf.check_perl_version((5,6,0))
         conf.check_perl_ext_devel()
     conf.check_python_version((2,4,2))
-    conf.env.append_unique('CXXFLAGS', ['-O2', '-DVERSION_STRING=' + VERSION])
+    conf.env.append_unique('CXXFLAGS', ['-std=c++11', '-O2', '-DVERSION_STRING=' + VERSION])
     conf.env.INCLUDES += '.'
     conf.env.LIB += ['pthread', 'dl']
 


### PR DESCRIPTION
Useful to select reads with specific commentary information as description (not necessarily in the name part). Because, index only collect the read names (ids), this regex search does not work on the index mode.

This is probably convenient, but require recent compilers. For g++, 4.9 or higher is expected to work. Compiled with g++ in rh-devtoolset-3 (g++ (GCC) 4.9.2 20150212 (Red Hat 4.9.2-6)) or rh-devtoolset-4 (g++ (GCC) 5.2.1 20150902 (Red Hat 5.2.1-2)).  